### PR TITLE
Update org.kde.krdc.desktop

### DIFF
--- a/org.kde.krdc.desktop
+++ b/org.kde.krdc.desktop
@@ -1,7 +1,7 @@
 # KDE Config File
 [Desktop Entry]
 Type=Application
-Exec=krdc -qwindowtitle %c %u
+Exec=krdc -qwindowtitle %c %u & rm ~/.config/freerdp/known_hosts2
 Icon=krdc
 Terminal=false
 Name=KRDC


### PR DESCRIPTION
to automatically approve a server certificate (for rdp plugin key instead of / cert-ignore - / cert-tofu)